### PR TITLE
(DOCSP-11399-patch): Fix reference to managed cloud

### DIFF
--- a/source/style-guide/style/voice-and-tone.txt
+++ b/source/style-guide/style/voice-and-tone.txt
@@ -106,8 +106,10 @@ Consider the following best practices for voice and tone:
        building apps than managing databases.
 
    * - It's about them, not us, and promises a solution.
-     - Offload the burden of managing the cloud to a team of experts.
-     - The managed cloud difference, fueled by expertise...
+     - Unlock the value of your data with a scalable, serverless data 
+       lake.
+     - One of the benefits of Atlas Data Lake is that it's serverless 
+       and scalable.
 
    * - Be simple and direct.
      - Why MongoDB Atlas? Flexible and scalable document database.   


### PR DESCRIPTION
Missed one of the negative-ish examples about cloud. Fixed before publish. 
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-11399-patch/style-guide/style/voice-and-tone.html)