### PR TITLE
(DOCSP-12645): fix tools install instructions based on new hire issues

### DIFF
--- a/source/includes/steps-install.yaml
+++ b/source/includes/steps-install.yaml
@@ -127,8 +127,8 @@ content: |
 
    .. code-block:: sh
 
-      brew cask install xquartz
+      brew install --cask xquartz
 
-   Once XQuartz is installed,
-   `download and install Inkscape <https://inkscape.org/release/inkscape-0.92.2/mac-os-x/107/dmg/dl/>`__.
+   Once XQuartz is installed, `download and install Inkscape
+   <https://inkscape.org/release/inkscape-1.0.1/mac-os-x/1010-1015/dl/>`__.
 ...

--- a/source/includes/steps-install.yaml
+++ b/source/includes/steps-install.yaml
@@ -62,11 +62,19 @@ content: |
   The build tools require Python 3 and 2 *from Homebrew*. The version of Python
   which comes with macOS is unsupported and will **not** work.
 
-  Install Python by running:
+  Install Python 2 by running the following commmands:
 
   .. code-block:: sh
 
-     brew install python https://raw.githubusercontent.com/Homebrew/homebrew-core/86a44a0a552c673a05f11018459c9f5faae3becc/Formula/python@2.rb
+     curl -LO https://raw.githubusercontent.com/Homebrew/homebrew-core/86a44a0a552c673a05f11018459c9f5faae3becc/Formula/python@2.rb
+
+     brew install python@2.rb
+
+  Install Python 3 by running the following command:
+
+  .. code-block:: sh
+
+     brew install python@3.8
 
 ---
 
@@ -78,7 +86,23 @@ content: |
 
   .. code-block:: sh
 
-     python2 -m pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
+     python -m pip install -r https://raw.githubusercontent.com/mongodb/docs-tools/master/giza/requirements.txt
+
+  You might receive the an error containing the following text when you
+  try to install Giza, Sphinx, and their dependencies: 
+
+  .. code-block:: sh
+
+     No module named pip
+
+  If you receive this error, run the following commands, then try to
+  install Giza, Sphinx, and their dependencies again:
+
+  .. code-block:: sh
+
+     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+
+     python get-pip.py
 
 ---
 


### PR DESCRIPTION
As of 10/06/2020, the `brew` install method in the MongoDB docs build tool install instructions no longer works. In step 4, messaging similar to the following is returned:

`Error: Calling Installation of python@2 from a GitHub commit URL is disabled! Use 'brew extract python@2' to stable tap on GitHub instead.`

I've found a solution and updated the step accordingly. I've also added some additional troubleshooting context to help users work around another issue a new hire encountered re: pip.

[Stage](https://docs-mongodbcom-staging.corp.mongodb.com/meta/john.williams/DOCSP-12645/tutorials/install.html)

WIP pending testing and review.