### PR TITLE
DOCSP-23914 -- Information typing prototypes for the Server docs team 

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -2,7 +2,7 @@ name = "meta"
 title = "MongoDB Meta Documentation"
 intersphinx = ["https://www.mongodb.com/docs/manual/objects.inv"]
 toc_landing_pages = [ "/style-guide", "/writing", "/style", "/terminology", "/terminology/general-term-guidelines", 
-                      "/screenshots", "tutorials", "reference", "/tutorials/screencapture-tool" ]
+                      "/screenshots", "tutorials", "reference", "/tutorials/screencapture-tool", "information-types" ]
 
 [constants]
 rst =  "reStructuredText"

--- a/source/index.txt
+++ b/source/index.txt
@@ -11,3 +11,4 @@ The MongoDB Documentation Project
    /organization
    /practices
    /translation
+   /information-types

--- a/source/information-types.txt
+++ b/source/information-types.txt
@@ -1,0 +1,57 @@
+=================
+Information Types
+=================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+At its best, information typing is being aware of your audience's goal as you 
+start to write a page, and keeping the information you write focused on those goals.
+
+What Is Information Typing?
+---------------------------
+
+Information typing is: 
+
+- Separating content into categories and delivering roughly one type at a time.
+
+- Understanding the purpose of a page before you write it.
+
+- Answering the user question "why do I care?" or "what does this mean for me?" quickly.
+
+- Using a suggested format to help you get started on a blank page.
+
+What Types of Information are We Talking About?
+-----------------------------------------------
+
+We'll begin with three main information types.
+
+- Concept -- A concept page helps a user learn about a concept or new feature. 
+  It is intended to answer the questions "what is this?", "why do I care", and "how
+  does this work?". The audience for a concept page is users who have never used 
+  a particular feature or command. 
+
+- Task -- A task page helps a user do a job. The audience for a task page is 
+  users who want to accomplish a task. They may never have completed the task 
+  before, may only have done it a few times, or may need a refresher on the steps. 
+  The task page should contain all the necessary information for someone to 
+  complete the task, any necessary conceptual information, prerequisites, steps, 
+  and expected results. 
+
+- Reference -- A reference page delivers granular details about a thing. The 
+  audience for reference pages is experienced users. Apart from 
+  straightforward reference manual pages, reference pages can be anything that 
+  is a bulleted list or primarily a table of information. 
+
+.. toctree::
+   :titlesonly:
+
+   /information-types/task
+   /information-types/concept
+   /information-types/reference
+

--- a/source/information-types.txt
+++ b/source/information-types.txt
@@ -10,8 +10,8 @@ Information Types
    :depth: 1
    :class: singlecol
 
-.. note:: Work in Progress
-   This information typing section is a work in progress. The Server documentation
+.. note:: 
+   This information typing section is a Work in Progress. The Server documentation
    team started this project mid-2022 and we are in the process of reviewing with 
    the team and discussing the possibility of adoption.
 

--- a/source/information-types.txt
+++ b/source/information-types.txt
@@ -10,13 +10,20 @@ Information Types
    :depth: 1
    :class: singlecol
 
-At its best, information typing is being aware of your audience's goal as you 
-start to write a page, and keeping the information you write focused on those goals.
+.. note:: Work in Progress
+   This information typing section is a work in progress. The Server documentation
+   team started this project mid-2022 and we are in the process of reviewing with 
+   the team and discussing the possibility of adoption.
+
+This section contains details about information typing and prototypes showing how 
+we can apply this to our documentation. 
 
 What Is Information Typing?
 ---------------------------
 
-Information typing is: 
+At its best, information typing is being aware of your audience's goal as you 
+start to write a page, and keeping the information you write focused on those goals.
+Additionally, information typing is: 
 
 - Separating content into categories and delivering roughly one type at a time.
 

--- a/source/information-types/concept.txt
+++ b/source/information-types/concept.txt
@@ -1,0 +1,53 @@
+======================
+Concept Page Prototype
+======================
+
+A concept page helps a user learn about a concept or new feature. 
+It is intended to answer the questions "what is this?", "why do I care", and 
+"how does this work?". The audience for a concept page is users who have never
+used a particular feature or command. 
+
+The title is typically a noun or noun phrase. 
+
+A concept page begins with a brief introduction summarizing its contents, often 
+called a short description. The short description explains a little about the 
+concept and why the audience should care about it. 
+
+Use Cases
+---------
+This section is a collection of use cases to explain "What do I do with this 
+thing?" In general, use cases are short descriptions of how to use a feature. 
+They set expectations of when and how you might use a feature  and what 
+differentiates this feature from other options.  
+
+Behavior
+--------
+This section includes stuff you need to know before using a feature. It can be as long
+or short as appropriate. Some examples of technical details include:
+
+- Performance considerations / behavior alerts
+- Support for a feature (supported in sharded clusters, for example)
+- Version support 
+
+Tasks
+-----
+Link to the most common task pages related to this concept. Linking to all 
+task pages isn't necessary here; the goal of this section is to make sure users 
+can easily find common related tasks.
+
+- Link one
+- Link two
+- Link three
+
+Details
+-------
+This section is a brief unpacking of the technical details. It can be as long
+or short as appropriate. 
+
+Learn More
+----------
+This section appears on every information typed page. It does not replace 
+inline linking, but is intended to augment the information on the page with 
+related concepts, tasks, and reference material. Use it to link related pages 
+that are not already linked above, such as reference information, technical 
+deep dives, less commonly used task pages, or related concepts.

--- a/source/information-types/reference.txt
+++ b/source/information-types/reference.txt
@@ -1,0 +1,80 @@
+========================
+Reference Page Prototype
+========================
+
+A reference page provides quick information to experienced users of a product. 
+Reference pages may describe the use of a method, operator, or database command. 
+Information presented as a bulleted list or table is usually a reference page. 
+Release notes are another good example of a reference page.
+
+Usually, the title of a reference page is the name of the command, operator, or 
+method it describes.
+
+Definition
+----------
+A reference page begins with a brief introduction summarizing its contents, 
+often called a short description. The short description explains a little about 
+how the reference material is used, and may link to a concept and/or task page.
+
+Syntax
+------
+This is the sample syntax with the required parameters. 
+
+.. code-block:: javascript                                                 
+                                                                           
+   db.adminCommand(                                                        
+      {                                                                    
+        addShard: "<replica_set>/<hostname><:port>",                       
+        maxSize: <size>,                                                   
+        name: "<shard_name>"                                               
+      }                                                                    
+   )  
+
+Command Fields
+--------------
+The command takes the following fields:
+
+.. list-table::                                                            
+   :header-rows: 1                                                         
+   :widths: 20 20 10 60                                                       
+                                                                           
+   * - Field                                                               
+                                                                           
+     - Type 
+
+     - Necessity                                                               
+                                                                           
+     - Description
+
+   * - Parameter
+
+     - String
+
+     - Required
+
+     - String
+
+Behaviors
+---------
+Optional. 
+
+Behaviors should only apply to the operator being described on this page. 
+
+Examples
+--------
+Optional.
+
+This section could contain examples of the most common usages. We would populate
+Reference and Task page examples using includes, so that the examples are written
+once, consistent throughout, and easier to update.
+
+If an example is shared between task and reference, it should be written as an
+include.
+
+Learn More
+----------
+This section appears on every information typed page. It does not replace 
+inline linking, but is intended to augment the information on the page with 
+related concepts, tasks, and reference material. Use it to link related pages 
+that are not already linked above, such as reference information, technical 
+deep dives, less commonly used task pages, or related concepts. 

--- a/source/information-types/task.txt
+++ b/source/information-types/task.txt
@@ -1,0 +1,85 @@
+===================
+Task Page Prototype
+===================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+The audience for a task page is users who want to accomplish a task. They may 
+never have completed the task before, may only have done it a few times, or may 
+need a refresher on the steps. The task page should contain all the necessary 
+information for someone to complete the task: any necessary conceptual 
+information, prerequisites, steps, and expected results. 
+
+Task page titles begin with a present-tense action verb. 
+
+A task page begins with a brief introduction summarizing the task, often called 
+a short description. The short description briefly explains the task, and  
+answers the questions "What is this task?", "What is it used for?", and "Why do 
+I care?". This paragraph can include links out to important conceptual information 
+required for this task.
+
+About This Task
+---------------
+This is optional.
+Include important conceptual or behavioral information that's directly relevant 
+to the task. If task-related information is extensive, consider a bulleted list 
+that contains brief descriptions of important concepts and links to deeper reading.  
+
+Before You Begin
+----------------
+This is optional. 
+An ordered or unordered list of any prerequisites for the task.
+
+Steps
+-----
+These are the steps to complete the task. 
+In some cases, we recomend that you use a stepped content approach. In others, 
+a single statement and copyable command or syntax example.  In most cases, it's helpful 
+to include an example of what a successful result looks like. It could be a 
+brief description, code block, or screenshot. 
+
+.. procedure::
+   :style:  connected
+
+   .. step:: Take an action.
+     
+      Say a little more or provide additional substeps or examples.
+
+      .. note:: 
+     
+         Use admonitions sparingly. This note gives critical context or a tip 
+         for step completion. It could also include a link to more 
+         context or important information.
+
+   .. step:: Take another action.
+     
+      Say a little more or provide additional substeps or examples.
+
+
+Example
+-------
+This is optional.
+In some cases, you can work through a specific example throughout the steps. 
+In others, it is helpful to show a complete example at the end. In most cases, 
+it's helpful to include an example of what a successful result looks like. It 
+could be a brief description, code block, or screenshot. 
+
+Next Steps
+----------
+This is optional.
+If there is one or many logical next things to do, you can link to them here.
+
+Learn More
+----------
+This section appears on every information typed page. Use it to link related pages 
+that are not already linked above, such as reference information, technical 
+deep dives, less commonly used task pages, or related concepts. It does not replace 
+inline linking.
+
+

--- a/worker.sh
+++ b/worker.sh
@@ -1,2 +1,1 @@
-#!/bin/sh
-make html
+"build-and-stage-next-gen"


### PR DESCRIPTION
My goal with this PR is to merge the information typing prototypes into docs-meta at the top navigation level so that the Server docs team can review and edit these prototypes as part of our team information typing discussion. Ideally, the team will buy into this authoring approach and we can move the pages into the Style Guide. For now, I thought it was best to keep this separate for the formal Style Guide. 

Happy to chat if anyone has any questions. 


- Staging: https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-23914/information-types/
- https://jira.mongodb.org/browse/DOCSP-23914