### PR TITLE
Fix broken links in the style guide

### DIFF
--- a/source/style-guide/markup/directives/tables.txt
+++ b/source/style-guide/markup/directives/tables.txt
@@ -8,6 +8,3 @@ In Snooty, you can use only the ``list-table`` directive to build tables.
 The ``list-table`` directive generates a formatted table from a two-level
 bulleted list.
 
-To learn more about the ``list-table`` directive from the
-`{+docutils+} documentation </directives#list-table>`__.
-

--- a/source/style-guide/release-notes-guidelines.txt
+++ b/source/style-guide/release-notes-guidelines.txt
@@ -1,5 +1,4 @@
-.lbs
-. _release-notes-guidelines:
+.. _release-notes-guidelines:
 
 ========================
 Release Notes Guidelines

--- a/source/style-guide/release-notes-guidelines.txt
+++ b/source/style-guide/release-notes-guidelines.txt
@@ -1,4 +1,5 @@
-.. _release-notes-guidelines:
+.lbs
+. _release-notes-guidelines:
 
 ========================
 Release Notes Guidelines
@@ -9,8 +10,8 @@ Release Notes Guidelines
 This topic provides guidelines for writing release notes (RN) for
 MongoDB Cloud services APIs.
 
-A template for API RN is available in `on
-GitHub <https://github.com/rackerlabs/docs-repo-template/blob/master/api-guide-template/release-notes/releases/release-notes-template.rst>`__.
+Follow the Rackspace `Release Guidelines <https://docs.rackspace.com/docs/style-guide/release-notes-guidelines/>`__
+from the Rackspace Style Guide.
 
 For an example that illustrates most of these guidelines, see the
 :opsmgr:`Ops Manager Server Release Notes </release-notes/application/>`.

--- a/source/style-guide/style/links-and-cross-references.txt
+++ b/source/style-guide/style/links-and-cross-references.txt
@@ -192,9 +192,9 @@ Link and Cross-Reference Examples
        storage engines.
 
    * - The snapshot retention policy is described in
-       :atlas:`cloud-provider-retention-policy`.
+       :atlas:`</backup/cloud-backup/scheduling/>`.
      - The snapshot retention policy is described
-       :atlas:`later in the Atlas documentation <cloud-provider-retention-policy>`.
+       :atlas:`later in the Atlas documentation </backup/cloud-backup/scheduling>`.
 
    * - The following table lists which MongoDB versions and components
        the current releases of MongoDB Ops Manager support.

--- a/source/style-guide/style/links-and-cross-references.txt
+++ b/source/style-guide/style/links-and-cross-references.txt
@@ -192,7 +192,7 @@ Link and Cross-Reference Examples
        storage engines.
 
    * - The snapshot retention policy is described in
-       :atlas:`</backup/cloud-backup/scheduling/>`.
+       :atlas:`backup-cloud-backup-scheduling </backup/cloud-backup/scheduling>`.
      - The snapshot retention policy is described
        :atlas:`later in the Atlas documentation </backup/cloud-backup/scheduling>`.
 

--- a/source/style-guide/style/links-and-cross-references.txt
+++ b/source/style-guide/style/links-and-cross-references.txt
@@ -192,7 +192,7 @@ Link and Cross-Reference Examples
        storage engines.
 
    * - The snapshot retention policy is described in
-       :atlas:`backup-cloud-backup-scheduling </backup/cloud-backup/scheduling>`.
+       :atlas:`Backup Scheduling, Retention, and On-Demand Snapshots </backup/cloud-backup/scheduling>`.
      - The snapshot retention policy is described
        :atlas:`later in the Atlas documentation </backup/cloud-backup/scheduling>`.
 

--- a/source/style-guide/style/placeholder-variable-text.txt
+++ b/source/style-guide/style/placeholder-variable-text.txt
@@ -78,7 +78,7 @@ When creating placeholder text, use the following guidelines.
 
        - Don't separate the words with spaces or symbols
        - Capitalize the first letter of each word after the first word
-         (called :wikipedia:`camelCase </Camel_case>`)
+         (called :wikipedia:`camelCase <Camel_case>`)
        - Never capitalize the first word
 
        .. note::

--- a/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
+++ b/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
@@ -45,7 +45,7 @@ consistently throughout the documentation.
    same document can be confusing to users and translators, so avoid
    it when possible.
 
--  Avoid `neologisms <https://www.merriam-webster.com/dictionary/phrasal-verb/neologism>`__. Examples of neologisms -- or
+-  Avoid neologisms. Examples of neologisms -- or
    newly invented words -- are *marketecture* or *edutainment*. Most
    such words are specific to a single business culture and aren't
    understood in other cultures.

--- a/source/style-guide/writing/clarify-modifiers.txt
+++ b/source/style-guide/writing/clarify-modifiers.txt
@@ -91,7 +91,7 @@ Dangling Modifiers
 Modifier clauses at the beginning or end of a sentence should modify
 the subject of the main clause. When the subject is missing or the
 clause modifies another object in the sentence, the clause is called a
-:wikipedia:`dangling modifier </Dangling_modifier?oldid=877876557>`.
+:wikipedia:`dangling modifier <Dangling_modifier?oldid=877876557>`.
 
 .. list-table::
    :widths: 33 33 33


### PR DESCRIPTION
Found some broken links in the style guide:

- [List table page no longer exists](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/markup/directives/tables/)
- [Rackspace template no longer exists](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/release-notes-guidelines/)
- [Cloud docs ref removed without redirect](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/style/links-and-cross-references/)
- [Remove leading slash for wikipedia](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/style/placeholder-variable-text/)
- [MW url structure changed, not needed](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/terminology/general-term-guidelines/use-consistent-terms/)
- [Remove leading slash for wikipedia](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/113022-fix-broken-links/style-guide/writing/clarify-modifiers/#dangling-modifiers)