### PR TITLE
DOCSP-26952 standardize on ID

### DIFF
--- a/source/style-guide/style/capitalization.txt
+++ b/source/style-guide/style/capitalization.txt
@@ -94,6 +94,9 @@ Following are some examples.
    * - GHz
      - gigahertz
 
+   * - ID
+     - identification
+
    * - I/O
      - input/output
 
@@ -117,7 +120,8 @@ Following are some examples.
 
 .. seealso::
 
-   To learn more, see :ref:`abbreviations`.
+   To learn more, and for a list of common abbreviations, see
+   :ref:`abbreviations`.
 
 Capitalize Job Titles when Used as Titles
 -----------------------------------------

--- a/source/style-guide/style/capitalization.txt
+++ b/source/style-guide/style/capitalization.txt
@@ -95,7 +95,8 @@ Following are some examples.
      - gigahertz
 
    * - ID
-     - identification
+     - | identification
+       | Note: `_id` is never capitalized.
 
    * - I/O
      - input/output


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-26952-standardize-on-ID/style-guide/style/capitalization/#capitalize-most-abbreviations)

[JIRA](https://jira.mongodb.org/browse/DOCSP-26952)

The guide for ID usage was already there. Added a few lines to make it more discoverable. 
