### PR TITLE
Fix a broken source constant

### DIFF
--- a/source/style-guide/markup-guidelines.txt
+++ b/source/style-guide/markup-guidelines.txt
@@ -17,7 +17,7 @@ with Sphinx extensions.
 
 See `Introduction to reStructured Text <https://www.writethedocs.org/guide/writing/reStructuredText/>`__ for more information on {+rst-abbrev+}.
 
-Parts of {+rst}
+Parts of {+rst+}
 -------------------------
 
 Directives

--- a/source/style-guide/markup-guidelines.txt
+++ b/source/style-guide/markup-guidelines.txt
@@ -10,7 +10,7 @@ This section describes markup conventions for {+rst+} ({+rst-abbrev+}) and
 {+markdown+}.
 
 {+rst+} ({+rst-abbrev+})
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 MongoDB documentation uses {+rst+} ({+rst-abbrev+}) markup syntax
 with Sphinx extensions.


### PR DESCRIPTION
Fix a malformatted source constant

[Staging: Markup Guidelines](https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/121622-source-constant-fix/style-guide/markup-guidelines/)