### PR TITLE
(DOCSP-27404): VS Code install instructions out of date

### DIFF
--- a/source/snooty.txt
+++ b/source/snooty.txt
@@ -52,12 +52,8 @@ Installation
    This will only take effect in *new* terminal sessions.
 
 #. Select the :guilabel:`Extensions` pane by pressing Shift-Command(⌘)-X,
-   search for ``i80and.snooty``, and install it.
-
-   .. figure:: /images/vscode-install-snooty.png
-      :alt: VSCode extensions pane with snooty entered
-      :figwidth: 691px
-
+   search for ``Snooty``, and press **Install**.
+   
    This may take a moment while Snooty downloads and installs its dependencies.
 
 Usage


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-27404)