### PR TITLE
Revert "(DOCSP-27404): VS Code install instructions out of date"

### DIFF
--- a/source/snooty.txt
+++ b/source/snooty.txt
@@ -52,8 +52,12 @@ Installation
    This will only take effect in *new* terminal sessions.
 
 #. Select the :guilabel:`Extensions` pane by pressing Shift-Command(⌘)-X,
-   search for ``Snooty``, and press :guilabel:`Install`.
-   
+   search for ``i80and.snooty``, and install it.
+
+   .. figure:: /images/vscode-install-snooty.png
+      :alt: VSCode extensions pane with snooty entered
+      :figwidth: 691px
+
    This may take a moment while Snooty downloads and installs its dependencies.
 
 Usage


### PR DESCRIPTION
Reverts mongodb/docs-meta#137