### PR TITLE
Inconsistent capitalization info and typos

### DIFF
--- a/source/style-guide/error-message-guidelines.txt
+++ b/source/style-guide/error-message-guidelines.txt
@@ -6,7 +6,7 @@ Error Message Guidelines
 
 .. default-domain:: mongodb
 
-Developers often ask an Technical Writer to edit error messages
+Developers often ask a technical writer to edit error messages
 that they have written.
 
 When you edit error messages, use the writing guidelines in this Style

--- a/source/style-guide/markup/inline.txt
+++ b/source/style-guide/markup/inline.txt
@@ -31,7 +31,7 @@ To learn more about when to use these roles, see the style guide section on
 
      **bold**
 
-- To *emphasize* or *italicize* text, use two asterisks on both sides
+- To *emphasize* or *italicize* text, use one asterisk on both sides
   of the text.
 
   .. code-block:: rst

--- a/source/style-guide/quickstart.txt
+++ b/source/style-guide/quickstart.txt
@@ -89,9 +89,10 @@ the following ones to help you boost the effectiveness of your writing.
    * - **Use headline-style capitalization for all titles and
        headings**.
 
-       To meet headline-style capitalization requirements, capitalize the initial 
-       letter of every word in a phrase except for articles, coordinating conjunctions, 
-       prepositions, and the types of words outlined in the guidelines.
+       To meet headline-style (or title case) capitalization requirements, 
+       capitalize the initial letter of every word in a phrase except for 
+       articles, coordinating conjunctions, prepositions, and the types of words 
+       outlined in the :ref:`titles-and-headings` guide.
      - :ref:`titles-and-headings`
    * - **Write clear and consistent code examples**.
 

--- a/source/style-guide/quickstart.txt
+++ b/source/style-guide/quickstart.txt
@@ -86,11 +86,12 @@ the following ones to help you boost the effectiveness of your writing.
      - :ref:`use-correct-punctuation`
 
        :ref:`punctuation`
-   * - **Use headline-style capitalization for most titles and
+   * - **Use headline-style capitalization for all titles and
        headings**.
 
        To meet headline-style capitalization requirements, capitalize the initial 
-       letter of the first, last, and all significant words in a phrase.
+       letter of every word in a phrase except for articles, coordinating conjunctions, 
+       prepositions, and the types of words outlined in the guidelines.
      - :ref:`titles-and-headings`
    * - **Write clear and consistent code examples**.
 

--- a/source/style-guide/quickstart.txt
+++ b/source/style-guide/quickstart.txt
@@ -86,10 +86,10 @@ the following ones to help you boost the effectiveness of your writing.
      - :ref:`use-correct-punctuation`
 
        :ref:`punctuation`
-   * - **Use headline-style capitalization for all titles and
+   * - **Use AP headline-style capitalization for all titles and
        headings**.
 
-       To meet headline-style (or title case) capitalization requirements, 
+       To meet AP headline-style (or AP title case) capitalization requirements, 
        capitalize the initial letter of every word in a phrase except for 
        articles, coordinating conjunctions, prepositions, and the types of words 
        outlined in the :ref:`titles-and-headings` guide.

--- a/source/style-guide/quickstart.txt
+++ b/source/style-guide/quickstart.txt
@@ -90,9 +90,7 @@ the following ones to help you boost the effectiveness of your writing.
        headings**.
 
        To meet AP headline-style (or AP title case) capitalization requirements, 
-       capitalize the initial letter of every word in a phrase except for 
-       articles, coordinating conjunctions, prepositions, and the types of words 
-       outlined in the :ref:`titles-and-headings` guide.
+       refer to the guidelines in the :ref:`titles-and-headings` guide.
      - :ref:`titles-and-headings`
    * - **Write clear and consistent code examples**.
 

--- a/source/style-guide/quickstart.txt
+++ b/source/style-guide/quickstart.txt
@@ -86,12 +86,11 @@ the following ones to help you boost the effectiveness of your writing.
      - :ref:`use-correct-punctuation`
 
        :ref:`punctuation`
-   * - **Use sentence-style capitalization for all titles and
+   * - **Use headline-style capitalization for most titles and
        headings**.
 
-       In sentence-style capitalization, you capitalize only the first
-       word of the title or heading, plus any proper terms and terms
-       that are always capitalized, such as some abbreviations.
+       To meet headline-style capitalization requirements, capitalize the initial 
+       letter of the first, last, and all significant words in a phrase.
      - :ref:`titles-and-headings`
    * - **Write clear and consistent code examples**.
 

--- a/source/style-guide/screenshots/diagram-guidelines.txt
+++ b/source/style-guide/screenshots/diagram-guidelines.txt
@@ -101,7 +101,7 @@ Text Formatting
 -  **Font**: Set the font to **Helvetica**.
 
 -  **Titles:** Title must be **bolded**, aligned **left**, and be at
-   least **24px** in size. Use sentence-style capitalization.
+   least **24px** in size. Use headline-style capitalization.
 
 Objects
 ~~~~~~~

--- a/source/style-guide/style/punctuation.txt
+++ b/source/style-guide/style/punctuation.txt
@@ -236,7 +236,7 @@ examples.
 Don't use an ellipsis in header text of table columns or when showing
 the name of an interface element—such as a text box, menu, menu
 command, or command button—even if the ellipsis is displayed on the
-interface. For example, don't use an ellipsis as follows: 
+interface. For example, don't use an ellipsis as follows:
 
 - On the **File** menu, click **Open...**.
 - Do this ... *(column header)*

--- a/source/style-guide/style/punctuation.txt
+++ b/source/style-guide/style/punctuation.txt
@@ -138,7 +138,7 @@ in the *Chicago Manual of Style*.
        Unlike the other alarms in this list you set the network check
        alarm variable upon network check creation.
 
-       To learn more, see Upgrading Ops Manager.
+       To learn more see Upgrading Ops Manager.
 
    * - Don't use a comma between the verbs in a compound predicate.
      - These open-source Python clients run on Linux or Mac OS X
@@ -236,7 +236,7 @@ examples.
 Don't use an ellipsis in header text of table columns or when showing
 the name of an interface element—such as a text box, menu, menu
 command, or command button—even if the ellipsis is displayed on the
-interface. For example, don't use an ellipsis as follows:
+interface. For example, don't use an ellipsis as follows: 
 
 - On the **File** menu, click **Open...**.
 - Do this ... *(column header)*

--- a/source/style-guide/style/tables.txt
+++ b/source/style-guide/style/tables.txt
@@ -49,8 +49,8 @@ within tasks, procedures, and tutorials don't require titles.
 
 When creating table titles, use the following guidelines:
 
-- Use sentence-style capitalization for table titles. However, for
-  words that are always uppercase or always lowercase, match that case.
+- Use headline-style capitalization for table titles. See 
+  :ref:`titles-and-headings` for a list of capitalization guidelines.
 - Don't start a table title with an article (*a*, *an*, *the*).
 - Don't end a table title with a period or colon.
 - Place the title above the table, not below it, and format it in 

--- a/source/style-guide/style/tables.txt
+++ b/source/style-guide/style/tables.txt
@@ -49,8 +49,8 @@ within tasks, procedures, and tutorials don't require titles.
 
 When creating table titles, use the following guidelines:
 
-- Use headline-style capitalization for table titles. See 
-  :ref:`titles-and-headings` for a list of capitalization guidelines.
+- Use headline-style capitalization for table titles. To learn more, see 
+  :ref:`titles-and-headings`.
 - Don't start a table title with an article (*a*, *an*, *the*).
 - Don't end a table title with a period or colon.
 - Place the title above the table, not below it, and format it in 

--- a/source/style-guide/style/titles-and-headings.txt
+++ b/source/style-guide/style/titles-and-headings.txt
@@ -16,7 +16,7 @@ documentation.
 Capitalization
 --------------
 
-- Use *headline-style* capitalization for most titles and headings,
+- Use *AP headline-style* capitalization for most titles and headings,
   including article, chapter, table, figure, and example titles, as
   well as section and procedure headings.
 
@@ -28,7 +28,7 @@ Capitalization
 Guidelines for Headline-Style Capitalization
 --------------------------------------------
 
-Headline-style capitalization uses initial uppercase letters for the
+AP headline-style capitalization uses initial uppercase letters for the
 first, last, and all the significant words in the title.
 
 Capitalize all words in the title except for the following types of

--- a/source/style-guide/style/titles-and-headings.txt
+++ b/source/style-guide/style/titles-and-headings.txt
@@ -28,7 +28,7 @@ Capitalization
 Guidelines for Headline-Style Capitalization
 --------------------------------------------
 
-Title-style capitalization uses initial uppercase letters for the
+Headline-style capitalization uses initial uppercase letters for the
 first, last, and all the significant words in the title.
 
 Capitalize all words in the title except for the following types of

--- a/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
+++ b/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
@@ -45,10 +45,9 @@ consistently throughout the documentation.
    same document can be confusing to users and translators, so avoid
    it when possible.
 
--  Avoid neologisms. Examples of neologisms—or
-   newly invented words—are *marketecture* or *edutainment*. Most
-   such words are specific to a single business culture and aren't
-   understood in other cultures.
+-  Avoid neologisms. Examples of neologisms (newly invented words) 
+   include *marketecture* or *edutainment*. Most such words are specific 
+   to a single business culture and aren't understood in other cultures.
 
 -  Standardize words and spelling across a documentation set.
 

--- a/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
+++ b/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
@@ -46,7 +46,7 @@ consistently throughout the documentation.
    it when possible.
 
 -  Avoid neologisms. Examples of neologisms (newly invented words) 
-   include *marketecture* or *edutainment*. Most such words are specific 
+   include *marketecture* or *edutainment*. Most of these words are specific 
    to a single business culture and aren't understood in other cultures.
 
 -  Standardize words and spelling across a documentation set.

--- a/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
+++ b/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
@@ -45,8 +45,8 @@ consistently throughout the documentation.
    same document can be confusing to users and translators, so avoid
    it when possible.
 
--  Avoid neologisms. Examples of neologisms——or
-   newly invented words——are *marketecture* or *edutainment*. Most
+-  Avoid neologisms. Examples of neologisms—or
+   newly invented words—are *marketecture* or *edutainment*. Most
    such words are specific to a single business culture and aren't
    understood in other cultures.
 

--- a/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
+++ b/source/style-guide/terminology/general-term-guidelines/use-consistent-terms.txt
@@ -45,8 +45,8 @@ consistently throughout the documentation.
    same document can be confusing to users and translators, so avoid
    it when possible.
 
--  Avoid neologisms. Examples of neologisms -- or
-   newly invented words -- are *marketecture* or *edutainment*. Most
+-  Avoid neologisms. Examples of neologisms——or
+   newly invented words——are *marketecture* or *edutainment*. Most
    such words are specific to a single business culture and aren't
    understood in other cultures.
 


### PR DESCRIPTION
# Pull Request Process

Please read the
[Style Guide Review Process](https://wiki.corp.mongodb.com/display/DE/Technical+Writer+Style+Guide+Review+Process)
wiki page.

Contributors should take the following actions:

- Request a PR review in #docs-style-guide Slack channel.
- Add the Style Guide team reps as reviewers.
- If any reviewer requests changes, address them and request another review.
- When you receive PR review approvals from all the Style Guide team reps,
  they will merge the PR and notify you of the merge in the Slack channel.

# Pull Request Description

The main issue I'm aiming to correct involves capitalization guidelines: based on [this](https://www.mongodb.com/docs/meta/style-guide/style/titles-and-headings/#std-label-titles-and-headings) page and the Drivers docs conventions I've observed, most titles/headings are capitalized according to headline-style rules. Many pages of the style guide state otherwise (namely, that they all use sentence-style capitalization), so I've changed those files. Additionally, I've included typo corrections.

Staging URL: <https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/fix-inconsistencies/style-guide/>

