### PR TITLE
Clarification of acceptable use of "fail" and "disable"

### DIFF
--- a/source/style-guide/includes/terms/d.rst
+++ b/source/style-guide/includes/terms/d.rst
@@ -110,7 +110,7 @@ D
 
    disabled
      :icon-fa4:`exclamation-triangle` Use *inactive* to describe
-     commands, toggled options, or buttons on the interface. Use
+     commands, options, toggles, or buttons in the interface. Use
      *dimmed* to describe the appearance of an inactive command,
      option, or button; use *unavailable* to refer to its state. Don't
      use *disabled* to refer to individuals with disabilities.

--- a/source/style-guide/includes/terms/d.rst
+++ b/source/style-guide/includes/terms/d.rst
@@ -109,8 +109,8 @@ D
           -
 
    disabled
-     :icon-fa4:`exclamation-triangle` Don't use *disabled* to describe
-     inactive commands, options, or buttons on the interface. Use
+     :icon-fa4:`exclamation-triangle` Use *inactive* to describe
+     commands, toggled options, or buttons on the interface. Use
      *dimmed* to describe the appearance of an inactive command,
      option, or button; use *unavailable* to refer to its state. Don't
      use *disabled* to refer to individuals with disabilities.

--- a/source/style-guide/includes/terms/f.rst
+++ b/source/style-guide/includes/terms/f.rst
@@ -4,7 +4,10 @@ F
 .. glossary::
 
    fail to
-     :icon-fa4:`times-circle` Use *unable to* instead.
+     :icon-fa4:`times-circle` Use *unable to* instead when referring to an individual or
+     company. 
+     
+     Use of *fail* is acceptable to describe the performance of a system.
 
    FAQ
      Use the acronym *FAQ* to refer to an article or section that

--- a/source/style-guide/includes/terms/f.rst
+++ b/source/style-guide/includes/terms/f.rst
@@ -4,10 +4,10 @@ F
 .. glossary::
 
    fail to
-     :icon-fa4:`times-circle` Use *unable to* instead when referring to an individual or
+     :icon-fa4:`times-circle` Use *unable to* when you when refer to an individual or
      company. 
      
-     Use of *fail* is acceptable to describe the performance of a system.
+     You may use *fail* to describe system performance.
 
    FAQ
      Use the acronym *FAQ* to refer to an article or section that

--- a/source/style-guide/writing/use-positive-statements.txt
+++ b/source/style-guide/writing/use-positive-statements.txt
@@ -31,8 +31,9 @@ and are typically shorter.
 Avoid Negative Words
 --------------------
 
-Try to avoid the following negative words, using instead the suggested
-alternatives. However, always be honest and transparent about issues.
+Try to avoid the following negative words, using instead the suggested alternatives,
+particularly in reference to the user or the company. However, always be honest and
+transparent about issues, and accurately describe a system's performance.
 
 .. list-table::
    :widths: 50 50

--- a/source/style-guide/writing/use-positive-statements.txt
+++ b/source/style-guide/writing/use-positive-statements.txt
@@ -32,8 +32,8 @@ Avoid Negative Words
 --------------------
 
 Try to avoid the following negative words, using instead the suggested alternatives,
-particularly in reference to the user or the company. However, always be honest and
-transparent about issues, and accurately describe a system's performance.
+particularly in reference to the user or the company. However, always communicate honestly and
+transparently about issues, and accurately describe a system's performance.
 
 .. list-table::
    :widths: 50 50


### PR DESCRIPTION
# Pull Request Process

Please read the
[Style Guide Review Process](https://wiki.corp.mongodb.com/display/DE/Technical+Writer+Style+Guide+Review+Process)
wiki page.

Contributors should take the following actions:

- Request a PR review in #docs-style-guide Slack channel.
- Add the Style Guide team reps as reviewers.
- If any reviewer requests changes, address them and request another review.
- When you receive PR review approvals from all the Style Guide team reps,
  they will merge the PR and notify you of the merge in the Slack channel.

# Pull Request Description

JIRA URL: <https://jira.mongodb.org/browse/DOCSP-33817> (related to, but does not solve)

Staging URL:
 - https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-33817-disable-fail/style-guide/writing/use-positive-statements/
 - https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-33817-disable-fail/style-guide/terminology/alphabetical-terms/#f
 - https://docs-mongodbcom-staging.corp.mongodb.com/meta/docsworker-xlarge/DOCSP-33817-disable-fail/style-guide/terminology/alphabetical-terms/#d

Related Vale PR: <https://github.com/mongodb/mongodb-vale-action/pull/4>

## Recommendations 

### Use of "Fail"
Clarify use cases: "Fail" should not be used to describe the actions of an individual or company, but is acceptable to describe system performance. This should be stated more clearly in the style guide.

### Use of "Disable"

Clarify use cases:: "Disable" should be used only in cases that describe whether or not a system employs a feature. We should clarify alternatives more explicitly.
