### PR TITLE
DOCSP-45736-add-self-managed-to-glossary

### DIFF
--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -75,9 +75,6 @@ O
             hosted either on-premises or off-premises.
           -
 
-     .. note::
-
-        
    open
      .. seealso:: 
        

--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -49,10 +49,15 @@ O
 
    on-premises
      **off-premises**
-     Use these terms to distinguish local computing (in which
-     resources are located on a customer’s own site) from remote
-     computing (in which resources are provided partially or totally
-     through the cloud). Always hyphenate. *Premises* is plural;
+
+     :icon-fa4:`times-circle` Avoid when referring to non-Atlas
+     deployments. To refer to non-Atlas deployments, use
+     :term:`self-managed`.
+
+     When used in other contexts, use *on-premises* to distinguish local
+     computing (in which resources are located on a customer's own site)
+     from remote computing (in which resources are provided partially or
+     totally through the cloud). Always hyphenate. *Premises* is plural;
      don't use *on-premise* or *off-premise*.
 
      .. list-table::
@@ -72,7 +77,7 @@ O
 
      .. note::
 
-        To refer to non-Atlas deployments, use :term:`self-managed`.
+        
    open
      .. seealso:: 
        

--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -58,7 +58,8 @@ O
      resources are located on a customer's own site) from remote
      computing (in which resources are provided partially or totally
      through the cloud). Always hyphenate. *Premises* is plural; don't
-     use *on-premise* or *off-premise*.
+     use *on-premise* or *off-premise*. For consistency, always use the
+     complete *on-premises* term, and do not shorten to *on-prem*.
 
      .. list-table::
         :widths: 50 50

--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -70,6 +70,9 @@ O
             hosted either on-premises or off-premises.
           -
 
+     .. note::
+
+        To refer to non-Atlas deployments, use :term:`self-managed`.
    open
      .. seealso:: 
        
@@ -135,4 +138,3 @@ O
             MongoDB email hosting.
           - Over three million business email users rely on MongoDB
             email hosting.
-

--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -50,15 +50,15 @@ O
    on-premises
      **off-premises**
 
-     :icon-fa4:`times-circle` Avoid these terms when you distinguish
+     :icon-fa4:`times-circle` Avoid using these terms to distinguish
      non-Atlas deployments. To distinguish non-Atlas deployments, use
      :term:`self-managed`.
 
-     When you use *on-premises* in other contexts, use the term to
-     distinguish local computing (in which resources are located on a
-     customer's own site) from remote computing (in which resources are
-     provided partially or totally through the cloud). Always hyphenate.
-     *Premises* is plural; don't use *on-premise* or *off-premise*.
+     Use *on-premises* to distinguish local computing (in which
+     resources are located on a customer's own site) from remote
+     computing (in which resources are provided partially or totally
+     through the cloud). Always hyphenate. *Premises* is plural; don't
+     use *on-premise* or *off-premise*.
 
      .. list-table::
         :widths: 50 50

--- a/source/style-guide/includes/terms/o.rst
+++ b/source/style-guide/includes/terms/o.rst
@@ -50,15 +50,15 @@ O
    on-premises
      **off-premises**
 
-     :icon-fa4:`times-circle` Avoid when referring to non-Atlas
-     deployments. To refer to non-Atlas deployments, use
+     :icon-fa4:`times-circle` Avoid these terms when you distinguish
+     non-Atlas deployments. To distinguish non-Atlas deployments, use
      :term:`self-managed`.
 
-     When used in other contexts, use *on-premises* to distinguish local
-     computing (in which resources are located on a customer's own site)
-     from remote computing (in which resources are provided partially or
-     totally through the cloud). Always hyphenate. *Premises* is plural;
-     don't use *on-premise* or *off-premise*.
+     When you use *on-premises* in other contexts, use the term to
+     distinguish local computing (in which resources are located on a
+     customer's own site) from remote computing (in which resources are
+     provided partially or totally through the cloud). Always hyphenate.
+     *Premises* is plural; don't use *on-premise* or *off-premise*.
 
      .. list-table::
         :widths: 50 50

--- a/source/style-guide/includes/terms/s.rst
+++ b/source/style-guide/includes/terms/s.rst
@@ -69,6 +69,11 @@ S
      Usually words with the prefix *self*, such as *self-service* and
      *self-explanatory*, are hyphenated.
 
+   self-managed
+     Use to describe deployments that are not hosted on MongoDB Atlas.
+     Self-managed deployments include deployments that are hosted
+     on-premises as well as non-Atlas environments like AWS.
+
    serious
      Use *serious* instead of the more negative terms *bad*,
      *catastrophic*, or *fatal*.

--- a/source/style-guide/includes/terms/s.rst
+++ b/source/style-guide/includes/terms/s.rst
@@ -70,9 +70,9 @@ S
      *self-explanatory*, are hyphenated.
 
    self-managed
-     Use to describe deployments that are not hosted on MongoDB Atlas.
-     Self-managed deployments include deployments that are hosted
-     on-premises as well as non-Atlas environments like AWS.
+     Use this term to describe deployments that are not hosted on
+     MongoDB Atlas. Self-managed deployments include deployments that
+     are hosted on-premises as well as non-Atlas environments like AWS.
 
    serious
      Use *serious* instead of the more negative terms *bad*,


### PR DESCRIPTION
# Pull Request Process

Please read the
[Style Guide Review Process](https://wiki.corp.mongodb.com/display/DE/Technical+Writer+Style+Guide+Review+Process)
wiki page.

Contributors should take the following actions:

- Request a PR review in #docs-style-guide Slack channel.
- Add the Style Guide team reps as reviewers.
- If any reviewer requests changes, address them and request another review.
- When you receive PR review approvals from all the Style Guide team reps,
  they will merge the PR and notify you of the merge in the Slack channel.

# Pull Request Description

This PR adds a glossary entry for "self-managed deployments", used to refer to non-Atlas deployments. The goal of this PR is to standardize our terminology for non-Atlas deployments, since we currently use a mix of "self-managed", "self-hosted", and "on-premises".

The justification for "self-manged" over other terms is that this is the term proposed by Sarah Lin, and is the term we've been using as part of ongoing efforts in the manual to separate self-hosted and general MongoDB content.

JIRA URL: https://jira.mongodb.org/browse/DOCSP-45736

Staging:

- [List of Terms - O](https://deploy-preview-182--mongodb-docs-meta.netlify.app/style-guide/terminology/alphabetical-terms/#o) 
- [List of Terms - S](https://deploy-preview-182--mongodb-docs-meta.netlify.app/style-guide/terminology/alphabetical-terms/#s) 

