### PR TITLE
DOCSP-50528: typo fix

### DIFF
--- a/source/style-guide/writing/use-present-tense.txt
+++ b/source/style-guide/writing/use-present-tense.txt
@@ -29,7 +29,7 @@ emphasize that something occurs later from the users' perspective.
 The past tense may be used when you need to refer to a past event or,
 more often, an earlier software release. Limit references to earlier
 versions to the immediate prior release. If a user wants to learn about
-something earlier than that can refer to an earlier version of the
+something earlier than that they can refer to an earlier version of the
 documentation.
 
 .. tip::


### PR DESCRIPTION
# Pull Request Description
added 'they' between 'that' and 'can' in 'If a user wants to learn about something earlier than that can refer to an earlier version of the documentation.'

JIRA URL: <https://jira.mongodb.org/browse/DOCSP-50528>

Staging URL: <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/50528/>

